### PR TITLE
make codes work with newer version of compute capability and CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,17 +17,24 @@
 
 cmake_minimum_required(VERSION 2.4)
 project(sgm)
+
 find_package( OpenCV REQUIRED )
 find_package( CUDA REQUIRED )
 
+SET(OpenCV_DIR /home/lichi/packages/opencv3/build/installation/OpenCV-3.4.12/share/OpenCV)
+SET(OpenCV_INCLUDE_DIRS /home/lichi/packages/opencv3/build/installation/OpenCV-3.4.12/include)
+
+message(STATUS "OpenCV_INCLUDE_DIRS = ${OpenCV_INCLUDE_DIRS}")
+message(STATUS "OpenCV_DIR = ${OpenCV_DIR}")
+message(STATUS "OpenCV_LIBS = ${OpenCV_LIBS}")
 set(
     CUDA_NVCC_FLAGS
     ${CUDA_NVCC_FLAGS};
     -O3 -lineinfo
-    -gencode=arch=compute_30,code=sm_30
     -gencode=arch=compute_35,code=sm_35
     -gencode=arch=compute_50,code=sm_50
     -gencode=arch=compute_52,code=sm_52
+    -gencode=arch=compute_75,code=sm_75
     )
 
 cuda_add_executable(
@@ -35,3 +42,4 @@ cuda_add_executable(
     main.cu median_filter.cu hamming_cost.cu disparity_method.cu debug.cu costs.cu)
 
 target_link_libraries( sgm ${OpenCV_LIBS} )
+

--- a/util.h
+++ b/util.h
@@ -103,7 +103,8 @@ __inline__ __device__ int shfl_32(int scalarValue, const int lane) {
 	#if FERMI
 		return __emulated_shfl(scalarValue, (uint32_t)lane);
 	#else
-		return __shfl(scalarValue, lane);
+		//return __shfl(scalarValue, lane); deprecated
+		return __shfl_sync(0xffffffff,scalarValue, lane);
 	#endif
 }
 
@@ -113,7 +114,7 @@ __inline__ __device__ int shfl_up_32(int scalarValue, const int n) {
 		lane -= n;
 		return shfl_32(scalarValue, lane);
 	#else
-		return __shfl_up(scalarValue, n);
+		return __shfl_up_sync(0xffffffff,scalarValue, n);
 	#endif
 }
 
@@ -123,7 +124,7 @@ __inline__ __device__ int shfl_down_32(int scalarValue, const int n) {
 		lane += n;
 		return shfl_32(scalarValue, lane);
 	#else
-		return __shfl_down(scalarValue, n);
+		return __shfl_down_sync(0xffffffff,scalarValue, n);
 	#endif
 }
 
@@ -133,7 +134,7 @@ __inline__ __device__ int shfl_xor_32(int scalarValue, const int n) {
 		lane = lane ^ n;
 		return shfl_32(scalarValue, lane);
 	#else
-		return __shfl_xor(scalarValue, n);
+		return __shfl_xor_sync(0xffffffff,scalarValue, n);
 	#endif
 }
 


### PR DESCRIPTION
Make the code work for newer GPU and CUDA 9 and onward, since __shfl is deprecated after CUDA 9 and removed with compute capability 7.x or higher. 
Tested with RTX 2070 and Ubuntu 18.04
